### PR TITLE
Fix X3 auto-connect param mismatch and continue port scan

### DIFF
--- a/board_tools/ioloop.py
+++ b/board_tools/ioloop.py
@@ -241,12 +241,15 @@ def io_loop(exitflag, con_on, con_start, con_stop, con_succeed,
                 elif con_type.value == b"UDP":
                     debug_print("io_loop connect UDP")
                     data_connection = UDPConnection(udp_ip.value.decode(), UDP_LOCAL_DATA_PORT, udp_port.value)
+                else:
+                    raise ValueError(f"unsupported connection type: {con_type.value!r}")
                 con_succeed.value = 1 # success
             except Exception as e:
                 debug_print(str(type(e))+": "+str(e))
                 con_succeed.value = 2  # fail
                 if data_connection:
                     data_connection.close()
+                    data_connection = None
         elif log_start.value:
             debug_print("io_loop log start")
             log_file = open_log_file(log_path(), log_name.value.decode())

--- a/board_tools/src/tools/x3_unit.py
+++ b/board_tools/src/tools/x3_unit.py
@@ -47,27 +47,26 @@ class X3_Unit(IMUBoard):
             return None
 
     # indicate if it's proper config port.
-    # accept ping response of 2 (X3 config port) or 0 (old X3, other products), but not 1 (X3 data port)
+    # current X3 firmware returns APPNG,2 for config port.
     def check_control_port(self):
-        for _ in range(3):
+        for _ in range(8):
             code = self.parse_png_code(self.ping())
             if code is None:
                 continue
-            return code != 1
+            return code == 2
         return False
 
-    # ping data port instead.  accept 1 (X3 data port) or 0 (old X3, other products) but not 2 (config port)
-    # todo: should it handle old X3 firmware which has no config messaging on data port? then read output messaging.
+    # ping data port instead.
+    # current X3 firmware returns APPNG,1 for data port.
     def check_data_port(self):
         m = Message({'msgtype': b'PNG'})
-        for _ in range(3):
+        for _ in range(8):
             response = self.send_control_message(m, self.data_connection)
             code = self.parse_png_code(response)
             if code is None:
                 continue
-            return code != 2
-        # fallback for firmware/builds where config messaging on the data port is unreliable
-        return super().check_data_port()
+            return code == 1
+        return False
 
     # allow sending config messages on either port for X3. default to designated "control port"
     def send_control_message(self, message, connection=None):
@@ -76,13 +75,10 @@ class X3_Unit(IMUBoard):
 
         # clear and then write to whichever connection.
         # data port can have much more backlog at low baud, so clear with a longer latency window there.
-        clear_wait_s = DEFAULT_PORT_LATENCY_S
-        if connection is getattr(self, "data_connection", None):
-            clear_wait_s = MAX_PORT_LATENCY_S * 2
+        clear_wait_s = MAX_PORT_LATENCY_S * 2
         self.clear_connection(connection, self.control_scheme, clear_wait_s)
         self.control_scheme.write_one_message(message, connection)
-        if connection is getattr(self, "data_connection", None):
-            time.sleep(1e-2)
+        time.sleep(1e-2)
         resp = self.read_one_control_message(connection)
         if resp:
             return resp

--- a/board_tools/src/tools/x3_unit.py
+++ b/board_tools/src/tools/x3_unit.py
@@ -86,8 +86,7 @@ class X3_Unit(IMUBoard):
                     self.control_port_name = control_port
                     self.control_baud = control_baud
 
-                    # for other products we read data baud here:  data_baud = self.get_data_baud_flash()
-                    #  but x3 has same baud on both ports. add that back if we allow separate bauds.
+                    # Current X3 firmware uses one shared BAU setting for both user UART ports.
                     data_baud = control_baud
                     self.data_baud = data_baud
 
@@ -95,7 +94,8 @@ class X3_Unit(IMUBoard):
                     if set_data_port:
                         data_port = self.find_data_port_gnss_imu() #this finds and connects, don't need to set self.data_connection
                         if data_port is None: #fail on data port not found
-                            return None
+                            self.release_connections()
+                            continue
                         self.data_port_name = data_port
                     return control_port, data_port, control_baud, data_baud
                 else:

--- a/board_tools/src/tools/x3_unit.py
+++ b/board_tools/src/tools/x3_unit.py
@@ -2,18 +2,19 @@
 # handle mixed binary or ASCII output messaging with ASCII config messaging
 
 import sys
+import time
 from pathlib import Path
 ABS_PATH = Path(__file__)
 sys.path.append(str(ABS_PATH.parent.parent.parent.parent))
 
 try:
-    from board import IMUBoard, DEFAULT_PORT_LATENCY_S
+    from board import IMUBoard, DEFAULT_PORT_LATENCY_S, MAX_PORT_LATENCY_S
     from binary_and_ascii_scheme import Binary_and_ASCII_Scheme
     from message_scheme import Message
     from readable_scheme import OUTPUT_MESSAGE_TYPES
     from connection import *
 except ModuleNotFoundError:
-    from tools.board import IMUBoard, DEFAULT_PORT_LATENCY_S
+    from tools.board import IMUBoard, DEFAULT_PORT_LATENCY_S, MAX_PORT_LATENCY_S
     from tools.binary_and_ascii_scheme import Binary_and_ASCII_Scheme
     from tools.message_scheme import Message
     from tools.readable_scheme import OUTPUT_MESSAGE_TYPES
@@ -29,29 +30,59 @@ class X3_Unit(IMUBoard):
         super().__init__(data_port=data_port, control_port=control_port, baud=baud, data_baud=data_baud,
                          data_scheme=data_scheme, control_scheme=control_scheme, try_manual=try_manual, timeout=timeout)
 
+    @staticmethod
+    def parse_png_code(response):
+        if not response or not response.valid or getattr(response, "msgtype", None) != b'PNG':
+            return None
+        code = getattr(response, "code", None)
+        if code is None:
+            return None
+        try:
+            if isinstance(code, bytes):
+                code = code.decode(errors="ignore").strip()
+            if isinstance(code, str):
+                code = code.strip()
+            return int(code)
+        except Exception:
+            return None
+
     # indicate if it's proper config port.
     # accept ping response of 2 (X3 config port) or 0 (old X3, other products), but not 1 (X3 data port)
     def check_control_port(self):
-        response = self.ping()
-        return response and response.valid and response.msgtype == b'PNG' and response.code != 1
+        for _ in range(3):
+            code = self.parse_png_code(self.ping())
+            if code is None:
+                continue
+            return code != 1
+        return False
 
     # ping data port instead.  accept 1 (X3 data port) or 0 (old X3, other products) but not 2 (config port)
     # todo: should it handle old X3 firmware which has no config messaging on data port? then read output messaging.
     def check_data_port(self):
         m = Message({'msgtype': b'PNG'})
-        response = self.send_control_message(m, self.data_connection)
-        return response and response.valid and response.msgtype == b'PNG' and response.code != 2
+        for _ in range(3):
+            response = self.send_control_message(m, self.data_connection)
+            code = self.parse_png_code(response)
+            if code is None:
+                continue
+            return code != 2
+        # fallback for firmware/builds where config messaging on the data port is unreliable
+        return super().check_data_port()
 
     # allow sending config messages on either port for X3. default to designated "control port"
     def send_control_message(self, message, connection=None):
         if connection is None:
             connection = self.control_connection
 
-        # clear and then write to whichever connection, using the faster latency used for control port.
-        # assume same control and data schemes? otherwise have to pass scheme argument too.
-        self.clear_connection(connection, self.control_scheme, DEFAULT_PORT_LATENCY_S)
+        # clear and then write to whichever connection.
+        # data port can have much more backlog at low baud, so clear with a longer latency window there.
+        clear_wait_s = DEFAULT_PORT_LATENCY_S
+        if connection is getattr(self, "data_connection", None):
+            clear_wait_s = MAX_PORT_LATENCY_S * 2
+        self.clear_connection(connection, self.control_scheme, clear_wait_s)
         self.control_scheme.write_one_message(message, connection)
-        # time.sleep(1e-1)  # wait for response, seems to need it if UDPConnection has timeout 0.
+        if connection is getattr(self, "data_connection", None):
+            time.sleep(1e-2)
         resp = self.read_one_control_message(connection)
         if resp:
             return resp

--- a/board_tools/src/tools/x3_unit.py
+++ b/board_tools/src/tools/x3_unit.py
@@ -109,5 +109,5 @@ class X3_Unit(IMUBoard):
 
 
 if __name__ == "__main__":
-    x = X3_unit(data_port="COM11", control_port="COM12", timeout=0.4)
+    x = X3_Unit(data_port="COM11", control_port="COM12", timeout=0.4)
     print("done")

--- a/x3_tool.py
+++ b/x3_tool.py
@@ -46,6 +46,7 @@ with open(os.devnull, "w") as f, redirect_stdout(f):
 
 
 X3_TOOL_VERSION = "1.0"
+IO_CONNECT_TIMEOUT_S = 8.0
 
 #interface for X3 configuration and logging
 class UserProgram:
@@ -81,6 +82,18 @@ class UserProgram:
 
         #any features which might or not be there - do based on firmware version?
         self.available_configs = []
+
+    # wait for io loop to report data-port connect outcome
+    # returns True on success, False on fail, None on timeout
+    def wait_for_ioloop_connect(self, timeout_s=IO_CONNECT_TIMEOUT_S):
+        deadline = time.time() + timeout_s
+        while self.con_succeed.value == 0:
+            if time.time() >= deadline:
+                return None
+            time.sleep(0.1)
+        data_success = (self.con_succeed.value == 1)  # 0 waiting, 1 succeed, 2 fail
+        self.con_succeed.value = 0
+        return data_success
 
     def mainloop(self):
         while True:
@@ -230,13 +243,13 @@ class UserProgram:
 
             #check success from ioloop. TODO - maybe check new_connection here - will be None for cancel, then dont wait
             debug_print("wait for connect success")
-            while self.con_succeed.value == 0:
-                time.sleep(0.1)
-                # should it time out eventually?
+            data_success = self.wait_for_ioloop_connect()
             debug_print("done waiting")
-            data_success = (self.con_succeed.value == 1) # 0 waiting, 1 succeed, 2 fail
+            if data_success is None:
+                self.release()
+                show_and_pause("timed out waiting for data port connection from io thread. Try reconnecting.")
+                continue
             debug_print("data success: "+str(data_success)+", control success: "+str(control_success))
-            self.con_succeed.value = 0
             if data_success and control_success:
                 return
             else:
@@ -270,6 +283,7 @@ class UserProgram:
         # get product info, or assume bad connection if can't read it
         if not self.product_info_on_connect(board):
             board.release_connections()
+            self.board = None
             show_and_pause("\nfailed to read product info. Check connection settings and try again.")
             return None
 
@@ -277,6 +291,7 @@ class UserProgram:
         self.com_port.value, self.data_port_baud.value, self.control_port_baud.value = data_port_name.encode(), board.data_baud, board.control_baud
         self.con_type.value = b"COM"
         self.con_on.value = 1
+        self.con_succeed.value = 0
         self.con_start.value = 1
         return {"type": "COM", "control port": board.control_port_name, "data port": data_port_name}
 
@@ -717,16 +732,31 @@ class UserProgram:
         # serial connection needs to use new bauds if they changed.
         new_control_baud = self.board.get_control_baud_flash()
         new_data_baud = self.board.get_data_baud_flash()
+        if new_control_baud is None:
+            new_control_baud = self.board.control_baud
+        if new_data_baud is None:
+            # X3 uses shared BAU in current firmware; fall back safely if read fails.
+            new_data_baud = new_control_baud if new_control_baud is not None else self.board.data_baud
+        if new_control_baud is None or new_data_baud is None:
+            show_and_pause("could not read baud settings after reset. reconnect manually.")
+            return
         print("\nrestarting")
         self.board.reset_with_waits(new_control_baud, new_data_baud)
 
         # tell ioloop to use the new data port baud
         self.data_port_baud.value = new_data_baud
-        self.con_start.value = 1
-        while self.con_succeed.value == 0:
-            time.sleep(0.1)
-        data_success = (self.con_succeed.value == 1)  # 0 waiting, 1 succeed, 2 fail
+        self.control_port_baud.value = new_control_baud
         self.con_succeed.value = 0
+        self.con_start.value = 1
+        data_success = self.wait_for_ioloop_connect()
+        if data_success is None:
+            self.release()
+            show_and_pause("timed out waiting for data reconnect after reset. Try reconnecting.")
+            return
+        if not data_success:
+            self.release()
+            show_and_pause("data reconnect failed after reset. Try reconnecting.")
+            return
 
     def plot(self):
         show_and_pause("Not implemented yet")
@@ -744,7 +774,7 @@ class UserProgram:
                 if not output_msg:
                     continue
                 # connection errors: retry. content errors like invalid fields/values don't retry
-                if output_msg.msgtype == b'ERR' and output_msg.msgtype in connection_errors:
+                if output_msg.msgtype == b'ERR' and hasattr(output_msg, "err") and output_msg.err in connection_errors:
                     continue
                 # invalid response message or unexpected response type: retry
                 if not proper_response(output_msg, response_types):

--- a/x3_tool.py
+++ b/x3_tool.py
@@ -98,15 +98,25 @@ class UserProgram:
         return data_success
 
     # conservative guard for low baud operation so output stream remains parseable.
-    # with current X3 message payload sizes, 115200 at 200 Hz can overflow effective UART throughput.
+    # target mapping:
+    # 57600->57 Hz, 115200->113 Hz, 230400/460800/921600->200 Hz.
     def validate_baud_odr_combo(self, configs_dict):
         try:
             baud = int(configs_dict.get("bau", "460800"))
             odr = int(configs_dict.get("odr", "200"))
         except Exception:
             return True, None
-        if baud <= 115200 and odr > 20:
-            return False, 20
+        if baud >= 230400:
+            max_odr = 200
+        elif baud >= 115200:
+            max_odr = 113
+        elif baud >= 57600:
+            max_odr = 57
+        else:
+            max_odr = 20
+
+        if odr > max_odr:
+            return False, max_odr
         return True, None
 
     def enforce_baud_odr_guard(self, new_configs):
@@ -121,15 +131,23 @@ class UserProgram:
         if valid:
             return new_configs
 
+        supported_odr = sorted([int(x) for x in CFG_VALUE_OPTIONS.get("odr", ["20", "50", "100", "200"])])
+        safe_odr = None
+        for option in supported_odr:
+            if option <= max_odr:
+                safe_odr = option
+        if safe_odr is None:
+            safe_odr = supported_odr[0]
+
         print(f"\nWarning: baud={combined.get('bau')} with odr={combined.get('odr')} can exceed link capacity.")
         options = [
-            f"Auto-adjust ODR to {max_odr} (recommended)",
+            f"Auto-adjust ODR to {safe_odr} (recommended, max {max_odr})",
             "Write anyway",
             "cancel",
         ]
         selected = options[cutie.select(options)]
         if selected == options[0]:
-            new_configs["odr"] = str(max_odr).encode()
+            new_configs["odr"] = str(safe_odr).encode()
             return new_configs
         if selected == options[1]:
             return new_configs

--- a/x3_tool.py
+++ b/x3_tool.py
@@ -52,7 +52,7 @@ class UserProgram:
 
     #(data_connection, logging_on, log_name, log_file, ntrip_on, ntrip_reader, ntrip_request, ntrip_ip, ntrip_port)
     def __init__(self, exitflag, con_on, con_start, con_stop, con_succeed,
-                 con_type, com_port, data_port_baud, config_port_baud, udp_ip, udp_port, gps_received,
+                 con_type, com_port, data_port_baud, control_port_baud, udp_ip, udp_port, gps_received,
                  log_on, log_start, log_stop, log_name,
                  ntrip_on, ntrip_start, ntrip_stop, ntrip_succeed,
                  ntrip_ip, ntrip_port, ntrip_gga, ntrip_req,
@@ -948,4 +948,3 @@ if __name__ == "__main__":
     io_process.start()
     runUserProg(*shared_args) # must do this in main thread so it can take inputs
     io_process.join()
-

--- a/x3_tool.py
+++ b/x3_tool.py
@@ -68,6 +68,8 @@ class UserProgram:
         self.shared_serial_number.value = b""
         self.version = ""
         self.product_id = ""
+        self.current_configs = {}
+        self.recovery_mode = False
 
         #keep the shared vars as class attributes so other UserProgram methods have them.
         #set them like self.log_name.value = x so change is shared. not self.log_name = x
@@ -94,6 +96,89 @@ class UserProgram:
         data_success = (self.con_succeed.value == 1)  # 0 waiting, 1 succeed, 2 fail
         self.con_succeed.value = 0
         return data_success
+
+    # conservative guard for low baud operation so output stream remains parseable.
+    # with current X3 message payload sizes, 115200 at 200 Hz can overflow effective UART throughput.
+    def validate_baud_odr_combo(self, configs_dict):
+        try:
+            baud = int(configs_dict.get("bau", "460800"))
+            odr = int(configs_dict.get("odr", "200"))
+        except Exception:
+            return True, None
+        if baud <= 115200 and odr > 20:
+            return False, 20
+        return True, None
+
+    def enforce_baud_odr_guard(self, new_configs):
+        combined = dict(self.current_configs)
+        for key, value in new_configs.items():
+            if isinstance(value, bytes):
+                combined[key] = value.decode(errors="ignore")
+            else:
+                combined[key] = str(value)
+
+        valid, max_odr = self.validate_baud_odr_combo(combined)
+        if valid:
+            return new_configs
+
+        print(f"\nWarning: baud={combined.get('bau')} with odr={combined.get('odr')} can exceed link capacity.")
+        options = [
+            f"Auto-adjust ODR to {max_odr} (recommended)",
+            "Write anyway",
+            "cancel",
+        ]
+        selected = options[cutie.select(options)]
+        if selected == options[0]:
+            new_configs["odr"] = str(max_odr).encode()
+            return new_configs
+        if selected == options[1]:
+            return new_configs
+        return None
+
+    def manual_recovery_connect(self):
+        probe = X3_Unit(try_manual=False)
+        port_names = probe.list_ports()
+        probe.release_connections()
+        if not port_names:
+            show_and_pause("no ports found.")
+            return None
+
+        options = port_names + ["cancel"]
+        print("\nselect configuration port")
+        control_port = options[cutie.select(options, selected_index=0)]
+        if control_port == "cancel":
+            return None
+
+        print("\nselect data port (optional for recovery)")
+        data_options = port_names + ["none", "cancel"]
+        data_port = data_options[cutie.select(data_options, selected_index=0)]
+        if data_port == "cancel":
+            return None
+        if data_port == control_port:
+            data_port = "none"
+
+        baud_options = [int(x) for x in CFG_VALUE_OPTIONS.get("bau", [460800])]
+        print("\nselect baud rate")
+        selected_baud = baud_options[cutie.select(baud_options, selected_index=0)]
+
+        board = X3_Unit(try_manual=False)
+        try:
+            board.control_connection = SerialConnection(control_port, selected_baud, timeout=TIMEOUT_REGULAR)
+            board.control_port_name = control_port
+            board.control_baud = selected_baud
+            board.data_baud = selected_baud
+
+            if data_port == "none":
+                board.data_connection = DummyConnection()
+                board.data_port_name = "N/A"
+            else:
+                board.data_connection = SerialConnection(data_port, selected_baud, timeout=TIMEOUT_REGULAR)
+                board.data_port_name = data_port
+            return board
+        except Exception as e:
+            board.release_connections()
+            show_and_pause("manual recovery connect failed. check ports/baud and try again.")
+            return None
 
     def mainloop(self):
         while True:
@@ -154,6 +239,7 @@ class UserProgram:
         self.stop_logging()
         #close_ntrip(self.ntrip_on, self.ntrip_reader)
         self.connection_info = None
+        self.recovery_mode = False
         if self.board:
             self.board.release_connections()  # must release or reconnecting to the same ports will error
             self.board = None
@@ -230,8 +316,15 @@ class UserProgram:
                     return  # canceled in the auto/manual/cancel menu
                 elif result:
                     new_connection = result
-                    self.connection_info = new_connection
+                    skip_data_wait = bool(new_connection.get("skip_data_wait", False))
+                    self.connection_info = {
+                        "type": new_connection["type"],
+                        "control port": new_connection["control port"],
+                        "data port": new_connection["data port"],
+                    }
                     control_success = True
+                    if skip_data_wait:
+                        return
                 else:  # connect_com failed: returns None
                     continue
 
@@ -259,8 +352,11 @@ class UserProgram:
 
     def connect_com(self):
         print("\nConnect by COM port:")
-        options = ["Auto", "Manual", "cancel"]
+        self.recovery_mode = False
+        options = ["Auto", "Manual", "Manual Recovery (write-only)", "cancel"]
         selected = options[cutie.select(options)]
+        start_data_io = True
+        recovery_connect = False
         if selected == "Auto":
             self.release()
             board = X3_Unit.auto(set_data_port=True)
@@ -273,27 +369,61 @@ class UserProgram:
             manual_result = board.connect_manually(set_data_port=True)
             if manual_result is None:
                 return None
+        elif selected == "Manual Recovery (write-only)":
+            self.release()
+            board = self.manual_recovery_connect()
+            if board is None:
+                return None
+            start_data_io = False
+            recovery_connect = True
         else:  # cancel
             return "cancel"
 
         self.board = board
         data_port_name = board.data_port_name
-        board.data_connection.close()
+        if start_data_io and hasattr(board, "data_connection"):
+            board.data_connection.close()
 
         # get product info, or assume bad connection if can't read it
         if not self.product_info_on_connect(board):
-            board.release_connections()
-            self.board = None
-            show_and_pause("\nfailed to read product info. Check connection settings and try again.")
-            return None
+            if recovery_connect:
+                self.recovery_mode = True
+                self.serialnum = "unknown"
+                self.version = "unknown"
+                self.product_id = "x3"
+                self.shared_serial_number.value = b""
+                show_and_pause(
+                    "\nConnected in recovery mode.\n"
+                    "Reads may fail at this baud/ODR. Use Unit Configuration to lower ODR or raise baud, then restart."
+                )
+            else:
+                board.release_connections()
+                self.board = None
+                show_and_pause("\nfailed to read product info. Check connection settings and try again.")
+                return None
+        else:
+            self.recovery_mode = False
+
+        if data_port_name is None:
+            data_port_name = "N/A"
 
         # let io_thread do the data connection - give it the signal, close this copy
-        self.com_port.value, self.data_port_baud.value, self.control_port_baud.value = data_port_name.encode(), board.data_baud, board.control_baud
+        shared_port = data_port_name if data_port_name != "N/A" else board.control_port_name
+        self.com_port.value, self.data_port_baud.value, self.control_port_baud.value = shared_port.encode(), board.data_baud, board.control_baud
         self.con_type.value = b"COM"
-        self.con_on.value = 1
-        self.con_succeed.value = 0
-        self.con_start.value = 1
-        return {"type": "COM", "control port": board.control_port_name, "data port": data_port_name}
+        if start_data_io:
+            self.con_on.value = 1
+            self.con_succeed.value = 0
+            self.con_start.value = 1
+        else:
+            self.con_on.value = 0
+            self.con_stop.value = 1
+        return {
+            "type": "COM",
+            "control port": board.control_port_name,
+            "data port": data_port_name,
+            "skip_data_wait": (not start_data_io),
+        }
 
     def product_info_on_connect(self, board):
         combinations = (
@@ -317,9 +447,15 @@ class UserProgram:
             return
         clear_screen()
         if not self.read_all_configs(self.board):  # show configs automatically
+            print("Could not read all configs.")
+            options = ["Recovery edit (write-only)", "Back"]
+            if options[cutie.select(options)] == "Recovery edit (write-only)":
+                self.recovery_mode = True
+                self.available_configs = ["bau", "odr", "mfm", "sync"]
+                self.set_cfg()
             return #false means read failed -> go back to menu
         #check connection again since error can be caught in read_all_configs
-        if not self.con_on.value:
+        if not self.con_on.value and not self.recovery_mode:
             return
         #print("configure:")
         actions = ["Edit", "Done"]
@@ -361,15 +497,41 @@ class UserProgram:
             value = input()
         args[code] = value.encode()
 
+        guarded_args = self.enforce_baud_odr_guard(dict(args))
+        if guarded_args is None:
+            return
+        args = guarded_args
+
+        # recovery mode: send write without waiting for response, so user can recover from overloaded streams.
+        if self.recovery_mode:
+            self.board.set_cfg_flash_no_wait(args)
+            for key, val in args.items():
+                self.current_configs[key] = val.decode(errors="ignore")
+            if "bau" in args:
+                try:
+                    new_baud = int(args["bau"].decode())
+                    self.board.control_baud = new_baud
+                    self.board.data_baud = new_baud
+                    self.control_port_baud.value = new_baud
+                    self.data_port_baud.value = new_baud
+                except Exception:
+                    pass
+            show_and_pause("\nSent config write in recovery mode. Restart unit and reconnect.")
+            return
+
         resp = self.retry_command(method=self.board.set_cfg_flash, args=[args], response_types=[b'CFG', b'ERR'])
         if not proper_response(resp, b'CFG'):
             show_and_pause("") # proper_response already shows error, just pause to see it.
+            return
+        for key, val in args.items():
+            self.current_configs[key] = val.decode(errors="ignore")
 
     # read and show all user configurations
     def read_all_configs(self, board):
         resp = self.retry_command(method=board.get_cfg_flash, args=[[]], response_types=[b'CFG'])
         if proper_response(resp, b'CFG'):
             configs_dict = resp.configurations
+            self.current_configs = {k: v.decode(errors="ignore") for k, v in configs_dict.items()}
 
             #TODO - print the configs in order of CFG_CODES_TO_NAMES,
             # and put available_configs in that order too? maybe not needed


### PR DESCRIPTION
## Summary
- rename x3_tool UserProgram constructor arg to control_port_baud to match usage and avoid NameError
- in X3 auto_port, continue scanning other ports when data port detection fails instead of returning early
- keep X3 behavior as shared BAU for control/data UARTs

## Validation
- python3 -m py_compile x3_tool.py board_tools/src/tools/x3_unit.py